### PR TITLE
Fix(Data): Fixed Velkhana's capture icon display

### DIFF
--- a/HunterPie/Game/Rise/Data/MonsterData.xml
+++ b/HunterPie/Game/Rise/Data/MonsterData.xml
@@ -1329,7 +1329,8 @@
             </Parts>
         </Monster>
         <Monster Id="114"
-                 Size="1765.78">
+                 Size="1765.78"
+                 IsNotCapturable="true">
             <Crowns Silver="1.11"
                     Gold="1.17"/>
             <Weaknesses>


### PR DESCRIPTION
Fixed an issue where the capture icon was displayed even though it was an elder dragon