### PR TITLE
Fix(Data): Fix Frostcraft's Name

### DIFF
--- a/HunterPie/Game/Rise/Data/AbnormalityData.xml
+++ b/HunterPie/Game/Rise/Data/AbnormalityData.xml
@@ -475,7 +475,7 @@
                      Category="Debuffs"/>
         <Abnormality Id="ABN_FROSTCRAFT"
                      Offset="7A8"
-                     Name="ABNORMALITY_FROSTCRAFT"
+                     Name="ABNORMALITY_FROSTCRAFT_RISE"
                      Icon="ICON_ARMORSKILL_WHITE"
                      IsBuildup="True"
                      MaxBuildup="100"


### PR DESCRIPTION
Fixed the Name field of Frostcraft because some languages have different Frostcraft names in MHW and MHR