### PR TITLE
Fix I/O exceptions.

### DIFF
--- a/HunterPie.Core/Networking/Http/HttpClientResponse.cs
+++ b/HunterPie.Core/Networking/Http/HttpClientResponse.cs
@@ -70,10 +70,9 @@ public class HttpClientResponse : IEventDispatcher, IDisposable
 
         try
         {
-            if (!Directory.Exists(outPath))
-                Directory.CreateDirectory(
-                    Path.GetDirectoryName(outPath)!
-                );
+            string directoryPath = Path.GetDirectoryName(outPath)!;
+            if (!Directory.Exists(directoryPath))
+                Directory.CreateDirectory(directoryPath);
 
             await using var output = new FileStream(
                 outPath,

--- a/HunterPie.Core/Remote/CDN.cs
+++ b/HunterPie.Core/Remote/CDN.cs
@@ -16,6 +16,7 @@ public class CDN
     private static readonly HashSet<string> NotFoundCache = new();
 
     private static readonly SemaphoreSlim semaphore = new SemaphoreSlim(1, 1);
+
     public static async Task<string> GetMonsterIconUrl(string imageName)
     {
         if (NotFoundCache.Contains(imageName))
@@ -23,13 +24,13 @@ public class CDN
 
         string localImage = ClientInfo.GetPathFor($"Assets/Monsters/Icons/{imageName}.png");
 
-        if (File.Exists(localImage))
-            return localImage;
-
         await semaphore.WaitAsync();
 
         try
         {
+            if (File.Exists(localImage))
+                return localImage;
+
             using HttpClient client = new HttpClientBuilder(CDN_BASE_URL)
                 .Get($"/Assets/Monsters/Icons/{imageName}.png")
                 .WithTimeout(TimeSpan.FromSeconds(5))

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ---
 
-**[<kbd> <br> :rocket: Install <br> </kbd>][Installation]** 
+**[<kbd> <br> 🚀 Install <br> </kbd>][Installation]** 
 **[<kbd> <br> 📘 Documentation <br> </kbd>][Documentation]** 
 **[<kbd> <br> 🕹 Features <br> </kbd>][Features]** 
 **[<kbd> <br> 💙 Contribute <br> </kbd>][Contribution]**  


### PR DESCRIPTION
While recompiling HunterPie to .NET 8.0 I found out in the Directory.CreateDirectory method was being used to create a directory at the path specified by outPath. Then, the FileStream constructor was being used to create a file at the same path. 

This was causing a conflict because a directory and a file cannot have the same path.

Error in logs that was fixed:
```
System.IO.IOException: The process cannot access the file 'C:\Users\%username%\Downloads\Monster Hunter Rise\pie\Assets\Monsters\Icons\Rise_Unknown.png' because it is being used by another process.
   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
   at HunterPie.Core.Networking.Http.HttpClientResponse.DownloadAsync(String outPath)
```