### PR TITLE
Added ability to toggle DPS/total damage on/off for Damage Widget

### DIFF
--- a/HunterPie.Core/Client/Configuration/Overlay/DamageMeterWidgetConfig.cs
+++ b/HunterPie.Core/Client/Configuration/Overlay/DamageMeterWidgetConfig.cs
@@ -30,6 +30,12 @@ public class DamageMeterWidgetConfig : IWidgetSettings, ISettings
     [ConfigurationProperty("DAMAGE_METER_ENABLE_OTOMOS", group: CommonConfigurationGroups.CUSTOMIZATIONS, availableGames: GameProcess.MonsterHunterRise)]
     public Observable<bool> ShouldShowOtomos { get; set; } = true;
 
+    [ConfigurationProperty("DAMAGE_METER_SHOULD_SHOW_DPS", group: CommonConfigurationGroups.CUSTOMIZATIONS)]
+    public Observable<bool> ShouldShowDPS { get; set; } = true;
+
+    [ConfigurationProperty("DAMAGE_METER_SHOULD_SHOW_DAMAGE", group: CommonConfigurationGroups.CUSTOMIZATIONS)]
+    public Observable<bool> ShouldShowDamage { get; set; } = true;
+
     [ConfigurationProperty("DAMAGE_METER_DPS_CALCULATION_STRATEGY_STRING", group: CommonConfigurationGroups.WIDGET)]
     public Observable<DPSCalculationStrategy> DpsCalculationStrategy { get; set; } = DPSCalculationStrategy.RelativeToJoin;
 

--- a/HunterPie.UI/Overlay/Widgets/Damage/View/PlayerDamageView.xaml
+++ b/HunterPie.UI/Overlay/Widgets/Damage/View/PlayerDamageView.xaml
@@ -121,6 +121,7 @@
         <TextBlock FontFamily="{StaticResource HUNTERPIE_DEFAULT_FONT}"
                    Foreground="{StaticResource WHITE}"
                    FontSize="16"
+                   Visibility="{Binding ShouldShowDPS.Value, Converter={StaticResource BooleanToVisibilityConverter}}"
                    VerticalAlignment="Center"
                    HorizontalAlignment="Left"
                    Margin="25,0,0,0"
@@ -141,13 +142,29 @@
         <TextBlock d:Text="26,354"
                    Text="{Binding Damage}"
                    FontFamily="{StaticResource HUNTERPIE_DEFAULT_FONT}"
-                   Foreground="{StaticResource HUNTERPIE_FOREGROUND_SECONDARY}"
-                   FontSize="12"
-                   VerticalAlignment="Bottom"
-                   HorizontalAlignment="Right"
-                   Margin="0,0,2,0" 
-                   Grid.Column="3"
-                   TextAlignment="Right"/>
+                   Visibility="{Binding ShouldShowDamage.Value, Converter={StaticResource BooleanToVisibilityConverter}}"
+                   Grid.Column="3">
+            <TextBlock.Style>
+                <Style TargetType="{x:Type TextBlock}">
+                    <Setter Property="Foreground" Value="{StaticResource HUNTERPIE_FOREGROUND_SECONDARY}"/>
+                    <Setter Property="FontSize" Value="12"/>
+                    <Setter Property="VerticalAlignment" Value="Bottom"/>
+                    <Setter Property="HorizontalAlignment" Value="Right"/>
+                    <Setter Property="Margin" Value="0,0,2,0"/>
+                    <Setter Property="TextAlignment" Value="Right"/>
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding ShouldShowDPS.Value}" Value="False">
+                            <Setter Property="Foreground" Value="{StaticResource WHITE}"/>
+                            <Setter Property="FontSize" Value="16"/>
+                            <Setter Property="VerticalAlignment" Value="Center"/>
+                            <Setter Property="HorizontalAlignment" Value="Left"/>
+                            <Setter Property="Margin" Value="25,0,0,0"/>
+                            <Setter Property="TextAlignment" Value="Left"/>
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </TextBlock.Style>
+        </TextBlock>
 
     </Grid>
     <UserControl.Style>

--- a/HunterPie.UI/Overlay/Widgets/Damage/ViewModels/PlayerViewModel.cs
+++ b/HunterPie.UI/Overlay/Widgets/Damage/ViewModels/PlayerViewModel.cs
@@ -59,5 +59,7 @@ public class PlayerViewModel : ViewModel
     // Settings related
     public Observable<bool> ShouldHighlightMyself => _config.ShouldHighlightMyself;
     public Observable<bool> ShouldBlurNames => _config.ShouldBlurNames;
+    public Observable<bool> ShouldShowDPS => _config.ShouldShowDPS;
+    public Observable<bool> ShouldShowDamage => _config.ShouldShowDamage;
 
 }


### PR DESCRIPTION
Localization PR: https://github.com/HunterPie/localization/pull/95

This adds options to HunterPie to display or hide DPS/total damage on the damage widget. I found the older PR for this: #450, and this should incorporate the suggestions from that one.