### PR TITLE
Revert DisableDpiAwareness

### DIFF
--- a/HunterPie/Properties/AssemblyInfo.cs
+++ b/HunterPie/Properties/AssemblyInfo.cs
@@ -11,7 +11,6 @@ using System.Windows.Media;
                                               //(used if a resource is not found in the page,
                                               // app, or any theme specific resource dictionaries)
 )]
-[assembly: DisableDpiAwareness]
 
 [assembly: AssemblyVersion("2.11.0.54")]
 [assembly: AssemblyFileVersion("2.11.0.54")]


### PR DESCRIPTION
Disabling DPI scaling would cause UI blur on high-resolution screens, and the issue with SiderBar on high-resolution screens has been fixed.