### PR TITLE
feat(overlay): apply rendering strategy to widgets only

### DIFF
--- a/HunterPie.UI/HunterPie.UI.csproj
+++ b/HunterPie.UI/HunterPie.UI.csproj
@@ -5,8 +5,8 @@
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <Configurations>Debug;Release;Deploy</Configurations>
-    <AssemblyVersion>2.12.0.368</AssemblyVersion>
-    <FileVersion>2.12.0.368</FileVersion>
+    <AssemblyVersion>2.12.0.369</AssemblyVersion>
+    <FileVersion>2.12.0.369</FileVersion>
     <LangVersion>11.0</LangVersion>
     <Authors>Haato</Authors>
     <Version>2.12.0.0</Version>

--- a/HunterPie.UI/Overlay/Components/WidgetBase.xaml.cs
+++ b/HunterPie.UI/Overlay/Components/WidgetBase.xaml.cs
@@ -1,4 +1,6 @@
-﻿using HunterPie.Core.Observability.Logging;
+﻿using HunterPie.Core.Client;
+using HunterPie.Core.Client.Configuration.Enums;
+using HunterPie.Core.Observability.Logging;
 using HunterPie.UI.Architecture.Extensions;
 using HunterPie.UI.Overlay.Enums;
 using HunterPie.UI.Platform.Windows.Native;
@@ -86,6 +88,12 @@ public partial class WidgetBase : Window, INotifyPropertyChanged
         CompositionTarget.Rendering += OnRender;
     }
 
+    protected override void OnSourceInitialized(EventArgs e)
+    {
+        ConfigureRenderingStrategy();
+        base.OnSourceInitialized(e);
+    }
+
     protected override void OnClosed(EventArgs e)
     {
         lock (_sync)
@@ -107,6 +115,21 @@ public partial class WidgetBase : Window, INotifyPropertyChanged
 
         _lastRender = DateTime.Now;
         _counter++;
+    }
+
+    private void ConfigureRenderingStrategy()
+    {
+        var hwndSource = PresentationSource.FromVisual(this) as HwndSource;
+
+        if (hwndSource?.CompositionTarget is null)
+            return;
+
+        hwndSource.CompositionTarget.RenderMode = ClientConfig.Config.Client.Render.Value switch
+        {
+            RenderingStrategy.Hardware => RenderMode.Default,
+            RenderingStrategy.Software => RenderMode.SoftwareOnly,
+            _ => throw new ArgumentOutOfRangeException()
+        };
     }
 
     protected override void OnClosing(CancelEventArgs e)

--- a/HunterPie/App.xaml.cs
+++ b/HunterPie/App.xaml.cs
@@ -1,5 +1,4 @@
 using HunterPie.Core.Client;
-using HunterPie.Core.Client.Configuration.Enums;
 using HunterPie.Core.Domain.Dialog;
 using HunterPie.Core.Observability.Logging;
 using HunterPie.DI;
@@ -14,8 +13,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Windows;
-using System.Windows.Interop;
-using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Threading;
 
@@ -43,8 +40,6 @@ public partial class App : Application
 
         DependencyProvider.LoadModules();
         await InitializerManager.InitializeAsync();
-
-        SetRenderingMode();
 
         ShutdownMode = ShutdownMode.OnMainWindowClose;
 
@@ -114,13 +109,6 @@ public partial class App : Application
     }
 
     private void SetUiThreadPriority() => Dispatcher.Thread.Priority = ThreadPriority.Highest;
-
-    private static void SetRenderingMode()
-    {
-        RenderOptions.ProcessRenderMode = ClientConfig.Config.Client.Render == RenderingStrategy.Hardware
-            ? RenderMode.Default
-            : RenderMode.SoftwareOnly;
-    }
 
     private void OnTrayShowClick(object? sender, EventArgs e)
     {

--- a/HunterPie/Properties/AssemblyInfo.cs
+++ b/HunterPie/Properties/AssemblyInfo.cs
@@ -11,5 +11,5 @@ using System.Windows;
                                               // app, or any theme specific resource dictionaries)
 )]
 
-[assembly: AssemblyVersion("2.12.0.206")]
-[assembly: AssemblyFileVersion("2.12.0.206")]
+[assembly: AssemblyVersion("2.12.0.207")]
+[assembly: AssemblyFileVersion("2.12.0.207")]


### PR DESCRIPTION
- Rendering strategy will only be applied to the widgets. HunterPie's client will be rendered on the GPU whenever possible