### PR TITLE
fix: clear log on runtime

### DIFF
--- a/HunterPie/Internal/Logger/FileStreamLogWriter.cs
+++ b/HunterPie/Internal/Logger/FileStreamLogWriter.cs
@@ -10,7 +10,7 @@ namespace HunterPie.Internal.Logger;
 internal class FileStreamLogWriter : ILogWriter
 {
     private bool _isClosed = false;
-    private static readonly FileStream Stream = File.OpenWrite(ClientInfo.GetPathFor("HunterPie_Log.txt"));
+    private static readonly FileStream Stream = File.Create(ClientInfo.GetPathFor("HunterPie_Log.txt"));
 
     public void Debug(string message) =>
         WriteToBuffer(LogLevel.Debug, message);


### PR DESCRIPTION
Implemented a fix for the log file creation process to ensure the log file is cleared at runtime.

This change addresses an issue where the log file was being rewritten line by line, resulting in mixed logs between sessions and occasional truncation.