### PR TITLE
feat(core): add support for formattable variant prefixes

### DIFF
--- a/HunterPie.Integrations/Datasources/MonsterHunterWilds/Entity/Enemy/MHWildsMonster.cs
+++ b/HunterPie.Integrations/Datasources/MonsterHunterWilds/Entity/Enemy/MHWildsMonster.cs
@@ -513,7 +513,7 @@ public sealed class MHWildsMonster : CommonMonster
             : $"Unknown [id: {variantId}]";
     }
 
-    private static string GetNameFormatString(ILocalizationRepository localizationRepository, string variantId)
+    private static string GetNameFormatString(string variantId, ILocalizationRepository localizationRepository)
     {
         string nameFormatPath = $"//Strings/Monsters/Formatting/Format[@Id='{variantId}']";
         return localizationRepository.ExistsBy(nameFormatPath)
@@ -550,7 +550,7 @@ public sealed class MHWildsMonster : CommonMonster
             variantLookupId = "FRENZIED";
         }
 
-        string nameFormatString = GetNameFormatString(localizationRepository, variantLookupId);
+        string nameFormatString = GetNameFormatString(variantLookupId, localizationRepository);
         string name = GetName(id, localizationRepository);
         string variantString = GetVariantString(variantLookupId, localizationRepository);
 

--- a/HunterPie.Integrations/Datasources/MonsterHunterWilds/Entity/Enemy/MHWildsMonster.cs
+++ b/HunterPie.Integrations/Datasources/MonsterHunterWilds/Entity/Enemy/MHWildsMonster.cs
@@ -550,20 +550,19 @@ public sealed class MHWildsMonster : CommonMonster
             variantLookupId = "ARCH_TEMPERED";
         }
 
-        sbNameFormatLookupId.Append(variantLookupId);
-
         string subVariantLookupId = string.Empty;
         if (variant.HasFlag(VariantType.Frenzy))
         {
             subVariantLookupId = "FRENZIED";
         }
 
-        if (sbNameFormatLookupId.Length > 0)
+        if (!string.IsNullOrEmpty(variantLookupId) && !string.IsNullOrEmpty(subVariantLookupId))
         {
-            sbNameFormatLookupId.Append("_");
+            sbNameFormatLookupId.AppendJoin("_", variantLookupId, subVariantLookupId);
+        } else
+        {
+            sbNameFormatLookupId.Append(!string.IsNullOrEmpty(variantLookupId) ? variantLookupId : subVariantLookupId);
         }
-
-        sbNameFormatLookupId.Append(subVariantLookupId);
 
         string name = GetName(id, localizationRepository);
         string localizedVariantString = GetLocalizedVariantString(variantLookupId, localizationRepository);

--- a/HunterPie.Integrations/Datasources/MonsterHunterWilds/Entity/Enemy/MHWildsMonster.cs
+++ b/HunterPie.Integrations/Datasources/MonsterHunterWilds/Entity/Enemy/MHWildsMonster.cs
@@ -521,7 +521,6 @@ public sealed class MHWildsMonster : CommonMonster
                 sb.Append(prefix);
                 sb.Append(' ');
                 sb.Append(name);
-
             }
         }
         else

--- a/HunterPie.Integrations/Datasources/MonsterHunterWilds/Entity/Enemy/MHWildsMonster.cs
+++ b/HunterPie.Integrations/Datasources/MonsterHunterWilds/Entity/Enemy/MHWildsMonster.cs
@@ -486,24 +486,19 @@ public sealed class MHWildsMonster : CommonMonster
     {
         var sb = new StringBuilder();
 
+        string prefix = "";
         if (variant.HasFlag(VariantType.Tempered))
         {
-            string prefix = localizationRepository.FindStringBy("//Strings/Monsters/Variants/Variant[@Id='TEMPERED']");
-            sb.Append(prefix);
-            sb.Append(' ');
+            prefix = localizationRepository.FindStringBy("//Strings/Monsters/Variants/Variant[@Id='TEMPERED']");
         }
         else if (variant.HasFlag(VariantType.ArchTempered))
         {
-            string prefix = localizationRepository.FindStringBy("//Strings/Monsters/Variants/Variant[@Id='ARCH_TEMPERED']");
-            sb.Append(prefix);
-            sb.Append(' ');
+            prefix = localizationRepository.FindStringBy("//Strings/Monsters/Variants/Variant[@Id='ARCH_TEMPERED']");
         }
 
         if (variant.HasFlag(VariantType.Frenzy))
         {
-            string prefix = localizationRepository.FindStringBy("//Strings/Monsters/Variants/Variant[@Id='FRENZIED']");
-            sb.Append(prefix);
-            sb.Append(' ');
+            prefix = localizationRepository.FindStringBy("//Strings/Monsters/Variants/Variant[@Id='FRENZIED']");
         }
 
         string namePath = $"//Strings/Monsters/Wilds/Monster[@Id='{id}']";
@@ -512,7 +507,27 @@ public sealed class MHWildsMonster : CommonMonster
             ? localizationRepository.FindStringBy(namePath)
             : $"Unknown [id: {id}]";
 
-        sb.Append(name);
+        bool hasPrefix = prefix.Length > 0;
+
+        if (hasPrefix)
+        {
+            bool prefixIsFormattable = prefix.Contains("{0}");
+            if (prefixIsFormattable)
+            {
+                sb.AppendFormat(prefix, name);
+            }
+            else
+            {
+                sb.Append(prefix);
+                sb.Append(' ');
+                sb.Append(name);
+
+            }
+        }
+        else
+        {
+            sb.Append(name);
+        }
 
         return sb.ToString();
     }

--- a/HunterPie.Integrations/Datasources/MonsterHunterWilds/Entity/Enemy/MHWildsMonster.cs
+++ b/HunterPie.Integrations/Datasources/MonsterHunterWilds/Entity/Enemy/MHWildsMonster.cs
@@ -502,6 +502,14 @@ public sealed class MHWildsMonster : CommonMonster
             return value.PadRight(value.Length + pad);
         });
     }
+    private static string GetName(int id, ILocalizationRepository localizationRepository)
+    {
+        string namePath = $"//Strings/Monsters/Wilds/Monster[@Id='{id}']";
+        return localizationRepository.ExistsBy(namePath)
+            ? localizationRepository.FindStringBy(namePath)
+            : $"Unknown [id: {id}]";
+    }
+
     private static string BuildName(
         ILocalizationRepository localizationRepository,
         VariantType variant,
@@ -523,11 +531,8 @@ public sealed class MHWildsMonster : CommonMonster
             variantLookupId = "FRENZIED";
         }
 
-        string namePath = $"//Strings/Monsters/Wilds/Monster[@Id='{id}']";
+        string name = GetName(id, localizationRepository);
 
-        string name = localizationRepository.ExistsBy(namePath)
-            ? localizationRepository.FindStringBy(namePath)
-            : $"Unknown [id: {id}]";
 
         bool hasPrefix = prefix.Length > 0;
 

--- a/HunterPie.Integrations/Datasources/MonsterHunterWilds/Entity/Enemy/MHWildsMonster.cs
+++ b/HunterPie.Integrations/Datasources/MonsterHunterWilds/Entity/Enemy/MHWildsMonster.cs
@@ -518,7 +518,7 @@ public sealed class MHWildsMonster : CommonMonster
         string nameFormatPath = $"//Strings/Monsters/Formatting/Format[@Id='{variantId}']";
         return localizationRepository.ExistsBy(nameFormatPath)
             ? localizationRepository.FindStringBy(nameFormatPath)
-            : localizationRepository.FindStringBy("//Strings/Monsters/Formatting/Format[@Id='DEFAULT']");
+            : "{0:1}{1}";
     }
 
     private static string GetName(int id, ILocalizationRepository localizationRepository)

--- a/HunterPie.Integrations/Datasources/MonsterHunterWilds/Entity/Enemy/MHWildsMonster.cs
+++ b/HunterPie.Integrations/Datasources/MonsterHunterWilds/Entity/Enemy/MHWildsMonster.cs
@@ -518,7 +518,7 @@ public sealed class MHWildsMonster : CommonMonster
         string nameFormatPath = $"//Strings/Monsters/Formatting/Format[@Id='{variantId}']";
         return localizationRepository.ExistsBy(nameFormatPath)
             ? localizationRepository.FindStringBy(nameFormatPath)
-            : "{0:1}{1}";
+            : "{1:1}{0}";
     }
 
     private static string GetName(int id, ILocalizationRepository localizationRepository)

--- a/HunterPie.Integrations/Datasources/MonsterHunterWilds/Entity/Enemy/MHWildsMonster.cs
+++ b/HunterPie.Integrations/Datasources/MonsterHunterWilds/Entity/Enemy/MHWildsMonster.cs
@@ -502,6 +502,18 @@ public sealed class MHWildsMonster : CommonMonster
             return value.PadRight(value.Length + pad);
         });
     }
+
+    private static string GetVariantString(string variantId, ILocalizationRepository localizationRepository)
+    {
+        if (variantId == string.Empty)
+            return string.Empty;
+
+        string variantPath = $"//Strings/Monsters/Variants/Variant[@Id='{variantId}']";
+        return localizationRepository.ExistsBy(variantPath)
+            ? localizationRepository.FindStringBy(variantPath)
+            : $"Unknown [id: {variantId}]";
+    }
+
     private static string GetName(int id, ILocalizationRepository localizationRepository)
     {
         string namePath = $"//Strings/Monsters/Wilds/Monster[@Id='{id}']";
@@ -532,6 +544,7 @@ public sealed class MHWildsMonster : CommonMonster
         }
 
         string name = GetName(id, localizationRepository);
+        string variantString = GetVariantString(variantLookupId, localizationRepository);
 
 
         bool hasPrefix = prefix.Length > 0;

--- a/HunterPie.Integrations/Datasources/MonsterHunterWilds/Entity/Enemy/MHWildsMonster.cs
+++ b/HunterPie.Integrations/Datasources/MonsterHunterWilds/Entity/Enemy/MHWildsMonster.cs
@@ -514,6 +514,14 @@ public sealed class MHWildsMonster : CommonMonster
             : $"Unknown [id: {variantId}]";
     }
 
+    private static string GetNameFormatString(ILocalizationRepository localizationRepository, string variantId)
+    {
+        string nameFormatPath = $"//Strings/Monsters/Formatting/Format[@Id='{variantId}']";
+        return localizationRepository.ExistsBy(nameFormatPath)
+            ? localizationRepository.FindStringBy(nameFormatPath)
+            : localizationRepository.FindStringBy("//Strings/Monsters/Formatting/Format[@Id='DEFAULT']");
+    }
+
     private static string GetName(int id, ILocalizationRepository localizationRepository)
     {
         string namePath = $"//Strings/Monsters/Wilds/Monster[@Id='{id}']";
@@ -543,6 +551,7 @@ public sealed class MHWildsMonster : CommonMonster
             variantLookupId = "FRENZIED";
         }
 
+        string nameFormatString = GetNameFormatString(localizationRepository, variantLookupId);
         string name = GetName(id, localizationRepository);
         string variantString = GetVariantString(variantLookupId, localizationRepository);
 

--- a/HunterPie.Integrations/Datasources/MonsterHunterWilds/Entity/Enemy/MHWildsMonster.cs
+++ b/HunterPie.Integrations/Datasources/MonsterHunterWilds/Entity/Enemy/MHWildsMonster.cs
@@ -555,28 +555,12 @@ public sealed class MHWildsMonster : CommonMonster
         string name = GetName(id, localizationRepository);
         string variantString = GetVariantString(variantLookupId, localizationRepository);
 
+        string formattedName = BuildFormattedName(
+            format: nameFormatString,
+            name: name,
+            variant: variantString
+        );
 
-        bool hasPrefix = prefix.Length > 0;
-
-        if (hasPrefix)
-        {
-            bool prefixIsFormattable = prefix.Contains("{0}");
-            if (prefixIsFormattable)
-            {
-                sb.AppendFormat(prefix, name);
-            }
-            else
-            {
-                sb.Append(prefix);
-                sb.Append(' ');
-                sb.Append(name);
-            }
-        }
-        else
-        {
-            sb.Append(name);
-        }
-
-        return sb.ToString();
+        return formattedName;
     }
 }

--- a/HunterPie.Integrations/Datasources/MonsterHunterWilds/Entity/Enemy/MHWildsMonster.cs
+++ b/HunterPie.Integrations/Datasources/MonsterHunterWilds/Entity/Enemy/MHWildsMonster.cs
@@ -18,6 +18,7 @@ using HunterPie.Integrations.Datasources.MonsterHunterWilds.Entity.Crypto;
 using HunterPie.Integrations.Datasources.MonsterHunterWilds.Entity.Enemy.Data;
 using HunterPie.Integrations.Datasources.MonsterHunterWilds.Utils;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace HunterPie.Integrations.Datasources.MonsterHunterWilds.Entity.Enemy;
 
@@ -478,6 +479,29 @@ public sealed class MHWildsMonster : CommonMonster
         return variant;
     }
 
+    private static string BuildFormattedName(string format, string name, string variant)
+    {
+        return Regex.Replace(format, @"\{(\d+)(?::(\d+))?\}", match =>
+        {
+            // The first group is the position, the second is the padding
+            int position = int.Parse(match.Groups[1].Value);
+            int pad = match.Groups[2].Success ? int.Parse(match.Groups[2].Value) : 0;
+            // The value we return is the name or variant mapped to the relevant position from the format string
+            string value = string.Empty;
+            switch (position)
+            {
+                case 0:
+                    value = name;
+                    break;
+                case 1:
+                    value = variant;
+                    break;
+                default:
+                    break;
+            }
+            return value.PadRight(value.Length + pad);
+        });
+    }
     private static string BuildName(
         ILocalizationRepository localizationRepository,
         VariantType variant,

--- a/HunterPie.Integrations/Datasources/MonsterHunterWilds/Entity/Enemy/MHWildsMonster.cs
+++ b/HunterPie.Integrations/Datasources/MonsterHunterWilds/Entity/Enemy/MHWildsMonster.cs
@@ -479,7 +479,7 @@ public sealed class MHWildsMonster : CommonMonster
         return variant;
     }
 
-    private static string BuildFormattedName(string format, string name, string variant)
+    private static string FormatName(string format, string name, string variant)
     {
         return Regex.Replace(format, @"\{(\d+)(?::(\d+))?\}", match =>
         {
@@ -554,7 +554,7 @@ public sealed class MHWildsMonster : CommonMonster
         string name = GetName(id, localizationRepository);
         string variantString = GetVariantString(variantLookupId, localizationRepository);
 
-        return BuildFormattedName(
+        return FormatName(
             format: nameFormatString,
             name: name,
             variant: variantString

--- a/HunterPie.Integrations/Datasources/MonsterHunterWilds/Entity/Enemy/MHWildsMonster.cs
+++ b/HunterPie.Integrations/Datasources/MonsterHunterWilds/Entity/Enemy/MHWildsMonster.cs
@@ -554,12 +554,10 @@ public sealed class MHWildsMonster : CommonMonster
         string name = GetName(id, localizationRepository);
         string variantString = GetVariantString(variantLookupId, localizationRepository);
 
-        string formattedName = BuildFormattedName(
+        return BuildFormattedName(
             format: nameFormatString,
             name: name,
             variant: variantString
         );
-
-        return formattedName;
     }
 }

--- a/HunterPie.Integrations/Datasources/MonsterHunterWilds/Entity/Enemy/MHWildsMonster.cs
+++ b/HunterPie.Integrations/Datasources/MonsterHunterWilds/Entity/Enemy/MHWildsMonster.cs
@@ -508,21 +508,19 @@ public sealed class MHWildsMonster : CommonMonster
         int id
     )
     {
-        var sb = new StringBuilder();
-
-        string prefix = "";
+        string variantLookupId = string.Empty;
         if (variant.HasFlag(VariantType.Tempered))
         {
-            prefix = localizationRepository.FindStringBy("//Strings/Monsters/Variants/Variant[@Id='TEMPERED']");
+            variantLookupId = "TEMPERED";
         }
         else if (variant.HasFlag(VariantType.ArchTempered))
         {
-            prefix = localizationRepository.FindStringBy("//Strings/Monsters/Variants/Variant[@Id='ARCH_TEMPERED']");
+            variantLookupId = "ARCH_TEMPERED";
         }
 
         if (variant.HasFlag(VariantType.Frenzy))
         {
-            prefix = localizationRepository.FindStringBy("//Strings/Monsters/Variants/Variant[@Id='FRENZIED']");
+            variantLookupId = "FRENZIED";
         }
 
         string namePath = $"//Strings/Monsters/Wilds/Monster[@Id='{id}']";

--- a/HunterPie.Integrations/Datasources/MonsterHunterWilds/Entity/Enemy/MHWildsMonster.cs
+++ b/HunterPie.Integrations/Datasources/MonsterHunterWilds/Entity/Enemy/MHWildsMonster.cs
@@ -502,7 +502,7 @@ public sealed class MHWildsMonster : CommonMonster
         });
     }
 
-    private static string GetVariantString(string variantId, ILocalizationRepository localizationRepository)
+    private static string GetLocalizedVariantString(string variantId, ILocalizationRepository localizationRepository)
     {
         if (variantId == string.Empty)
             return string.Empty;
@@ -552,12 +552,12 @@ public sealed class MHWildsMonster : CommonMonster
 
         string nameFormatString = GetNameFormatString(variantLookupId, localizationRepository);
         string name = GetName(id, localizationRepository);
-        string variantString = GetVariantString(variantLookupId, localizationRepository);
+        string localizedVariantString = GetLocalizedVariantString(variantLookupId, localizationRepository);
 
         return FormatName(
             format: nameFormatString,
             name: name,
-            variant: variantString
+            variant: localizedVariantString
         );
     }
 }

--- a/HunterPie.Integrations/Datasources/MonsterHunterWilds/Entity/Enemy/MHWildsMonster.cs
+++ b/HunterPie.Integrations/Datasources/MonsterHunterWilds/Entity/Enemy/MHWildsMonster.cs
@@ -479,7 +479,7 @@ public sealed class MHWildsMonster : CommonMonster
         return variant;
     }
 
-    private static string FormatName(string format, string name, string variant)
+    private static string FormatName(string format, string name, string variant, string subVariant)
     {
         return Regex.Replace(format, @"\{(\d+)(?::(\d+))?\}", match =>
         {
@@ -494,6 +494,9 @@ public sealed class MHWildsMonster : CommonMonster
                     break;
                 case 1:
                     value = variant;
+                    break;
+                case 2:
+                    value = subVariant;
                     break;
                 default:
                     break;
@@ -518,7 +521,7 @@ public sealed class MHWildsMonster : CommonMonster
         string nameFormatPath = $"//Strings/Monsters/Formatting/Format[@Id='{variantId}']";
         return localizationRepository.ExistsBy(nameFormatPath)
             ? localizationRepository.FindStringBy(nameFormatPath)
-            : "{1:1}{0}";
+            : "{1:1}{2:1}{0}";
     }
 
     private static string GetName(int id, ILocalizationRepository localizationRepository)
@@ -535,6 +538,8 @@ public sealed class MHWildsMonster : CommonMonster
         int id
     )
     {
+        StringBuilder sbNameFormatLookupId = new StringBuilder();
+
         string variantLookupId = string.Empty;
         if (variant.HasFlag(VariantType.Tempered))
         {
@@ -545,19 +550,33 @@ public sealed class MHWildsMonster : CommonMonster
             variantLookupId = "ARCH_TEMPERED";
         }
 
+        sbNameFormatLookupId.Append(variantLookupId);
+
+        string subVariantLookupId = string.Empty;
         if (variant.HasFlag(VariantType.Frenzy))
         {
-            variantLookupId = "FRENZIED";
+            subVariantLookupId = "FRENZIED";
         }
 
-        string nameFormatString = GetNameFormatString(variantLookupId, localizationRepository);
+        if (sbNameFormatLookupId.Length > 0)
+        {
+            sbNameFormatLookupId.Append("_");
+        }
+
+        sbNameFormatLookupId.Append(subVariantLookupId);
+
         string name = GetName(id, localizationRepository);
         string localizedVariantString = GetLocalizedVariantString(variantLookupId, localizationRepository);
+        string localizedSubVariantString = GetLocalizedVariantString(subVariantLookupId, localizationRepository);
+
+        string nameFormatLookupId = sbNameFormatLookupId.ToString();
+        string nameFormatString = GetNameFormatString(nameFormatLookupId, localizationRepository);
 
         return FormatName(
-            format: nameFormatString,
+            format: nameFormatString, 
             name: name,
-            variant: localizedVariantString
+            variant: localizedVariantString,
+            subVariant: localizedSubVariantString
         );
     }
 }

--- a/HunterPie.Integrations/Datasources/MonsterHunterWilds/Entity/Enemy/MHWildsMonster.cs
+++ b/HunterPie.Integrations/Datasources/MonsterHunterWilds/Entity/Enemy/MHWildsMonster.cs
@@ -483,9 +483,8 @@ public sealed class MHWildsMonster : CommonMonster
     {
         return Regex.Replace(format, @"\{(\d+)(?::(\d+))?\}", match =>
         {
-            // The first group is the position, the second is the padding
             int position = int.Parse(match.Groups[1].Value);
-            int pad = match.Groups[2].Success ? int.Parse(match.Groups[2].Value) : 0;
+            int padding = match.Groups[2].Success ? int.Parse(match.Groups[2].Value) : 0;
             // The value we return is the name or variant mapped to the relevant position from the format string
             string value = string.Empty;
             switch (position)
@@ -499,7 +498,7 @@ public sealed class MHWildsMonster : CommonMonster
                 default:
                     break;
             }
-            return value.PadRight(value.Length + pad);
+            return value.PadRight(value.Length + padding);
         });
     }
 


### PR DESCRIPTION
### Changes

- Updates Wilds monster `BuildName` method to support format/template strings from localization files

The intention with this change is to allow the localization file to dictate the formatting for monster variant prefixes, as detailed in #623.

_This is my first time working with C# so please do point out if I'm doing anything crazy._

### Implementation Details

The changes here update `BuildName` such that:

- If a variant prefix can be resolved
  - If the variant prefix contains a format token (`{0}`), use `AppendFormat` to build the name string based on the localized string template.
  - Otherwise build it as before, with simple `<variant><name>` formatting, using the English variant text.
- If a variant prefix cannot be resolved
  - Build the name string with no variant prefix - name only.

With these changes updating a respective localization file to include, for example:

```xml
    <Monsters>
        <Variants>
            <Variant Id="TEMPERED"
                     String="{0} (歴戦の個体)" />
            <Variant Id="ARCH_TEMPERED"
                     String="歴戦王{0}" />
            <Variant Id="FRENZIED"
                     String="狂竜化{0}" />
         </Variants>
      <!-- ... -->
      </Monsters>
```
Should then allow monster names to be rendered with whatever variant prefix formatting makes the most sense for that locale.

### Screenshots

1. _Monster names with variants, if no variant data exists in localization file._
![localised-prefix-without-variants](https://github.com/user-attachments/assets/e73e91e8-79a4-4d78-88be-c22359a7ae7c)

2. _Monster names with variants, if variant data **does** exist in localization file._
![localised-prefix-with-variants](https://github.com/user-attachments/assets/095fe160-8146-48ea-b96f-6a6d1f4673ac)

