### PR TITLE
hotfix: fixes to many different issues in v2.12

### DIFF
--- a/HunterPie.Core/Architecture/Events/SmartEventsTracker.cs
+++ b/HunterPie.Core/Architecture/Events/SmartEventsTracker.cs
@@ -33,7 +33,8 @@ public class SmartEventsTracker
         foreach (ISmartEvent @event in Instance.TrackedEvents.ToArray())
         {
             if (@event.References.Any())
-                @event.References.ToList().ForEach(reference =>
+                @event.References.ToList()
+                    .ForEach(reference =>
                         Logger.Warning(
                         $"Detected dangling event reference at {reference.DeclaringType?.FullName ?? "unknown"}::{reference.Name}"
                         )

--- a/HunterPie.Core/Converters/ObservableConverter.cs
+++ b/HunterPie.Core/Converters/ObservableConverter.cs
@@ -10,13 +10,20 @@ internal class ObservableConverter : JsonConverter
 
     public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
     {
-
         Type T = objectType.GetGenericArguments()[0];
-        object value = T.IsEnum
-            ? Enum.Parse(T, reader.Value.ToString())
-            : reader.Value != null
-                ? Convert.ChangeType(reader.Value, T)
-                : null;
+        object? value;
+        if (T.IsEnum)
+        {
+            string? stringValue = reader.Value?.ToString();
+            value = stringValue is not null && Enum.TryParse(T, stringValue, out object? enumValue)
+                ? enumValue
+                : Enum.GetValues(T).GetValue(0);
+        }
+        else
+        {
+            value = reader.Value is not null ? Convert.ChangeType(reader.Value, T) : null;
+        }
+
         object observable = Activator.CreateInstance(objectType, value);
 
         if (value is null)

--- a/HunterPie.Core/HunterPie.Core.csproj
+++ b/HunterPie.Core/HunterPie.Core.csproj
@@ -4,8 +4,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <Authors>Haato</Authors>
     <Configurations>Debug;Release;Deploy</Configurations>
-    <AssemblyVersion>2.12.0.362</AssemblyVersion>
-    <FileVersion>2.12.0.367</FileVersion>
+    <AssemblyVersion>2.12.0.363</AssemblyVersion>
+    <FileVersion>2.12.0.368</FileVersion>
     <LangVersion>11.0</LangVersion>
 	<Nullable>enable</Nullable>
 	<Version>2.12.0.0</Version>

--- a/HunterPie.Core/HunterPie.Core.csproj
+++ b/HunterPie.Core/HunterPie.Core.csproj
@@ -4,8 +4,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <Authors>Haato</Authors>
     <Configurations>Debug;Release;Deploy</Configurations>
-    <AssemblyVersion>2.12.0.364</AssemblyVersion>
-    <FileVersion>2.12.0.369</FileVersion>
+    <AssemblyVersion>2.12.0.366</AssemblyVersion>
+    <FileVersion>2.12.0.371</FileVersion>
     <LangVersion>11.0</LangVersion>
 	<Nullable>enable</Nullable>
 	<Version>2.12.0.0</Version>

--- a/HunterPie.Core/HunterPie.Core.csproj
+++ b/HunterPie.Core/HunterPie.Core.csproj
@@ -4,8 +4,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <Authors>Haato</Authors>
     <Configurations>Debug;Release;Deploy</Configurations>
-    <AssemblyVersion>2.12.0.366</AssemblyVersion>
-    <FileVersion>2.12.0.371</FileVersion>
+    <AssemblyVersion>2.12.0.367</AssemblyVersion>
+    <FileVersion>2.12.0.372</FileVersion>
     <LangVersion>11.0</LangVersion>
 	<Nullable>enable</Nullable>
 	<Version>2.12.0.0</Version>

--- a/HunterPie.Core/HunterPie.Core.csproj
+++ b/HunterPie.Core/HunterPie.Core.csproj
@@ -4,8 +4,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <Authors>Haato</Authors>
     <Configurations>Debug;Release;Deploy</Configurations>
-    <AssemblyVersion>2.12.0.363</AssemblyVersion>
-    <FileVersion>2.12.0.368</FileVersion>
+    <AssemblyVersion>2.12.0.364</AssemblyVersion>
+    <FileVersion>2.12.0.369</FileVersion>
     <LangVersion>11.0</LangVersion>
 	<Nullable>enable</Nullable>
 	<Version>2.12.0.0</Version>

--- a/HunterPie.DI/HunterPie.DI.csproj
+++ b/HunterPie.DI/HunterPie.DI.csproj
@@ -5,8 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<LangVersion>11.0</LangVersion>
-    <AssemblyVersion>1.0.0.154</AssemblyVersion>
-    <FileVersion>1.0.0.157</FileVersion>
+    <AssemblyVersion>1.0.0.155</AssemblyVersion>
+    <FileVersion>1.0.0.158</FileVersion>
   </PropertyGroup>
 
 </Project>

--- a/HunterPie.Integrations/Datasources/MonsterHunterRise/Entity/Enemy/MHRMonster.cs
+++ b/HunterPie.Integrations/Datasources/MonsterHunterRise/Entity/Enemy/MHRMonster.cs
@@ -35,7 +35,7 @@ public sealed class MHRMonster : CommonMonster
     private float _stamina;
     private float _captureThreshold;
     private readonly MHRMonsterAilment _enrage = new(MonsterAilmentRepository.Enrage);
-    private MHRMonsterPart? _qurioThreshold;
+    private readonly MHRMonsterPart? _qurioThreshold;
     private readonly Dictionary<long, MHRMonsterPart> _parts = new();
     private readonly ConcurrentDictionary<long, MHRMonsterAilment> _ailments = new();
     private readonly List<Element> _weaknesses = new();
@@ -175,7 +175,8 @@ public sealed class MHRMonster : CommonMonster
         IGameProcess process,
         IScanService scanService,
         nint address,
-        int id
+        int id,
+        MonsterType monsterType
     ) : base(process, scanService)
     {
         _address = address;
@@ -183,6 +184,9 @@ public sealed class MHRMonster : CommonMonster
         Id = id;
 
         _definition = MonsterRepository.FindBy(GameType.Rise, Id) ?? MonsterRepository.UnknownDefinition;
+
+        if (monsterType == MonsterType.Qurio)
+            _qurioThreshold = new MHRMonsterPart(MHRiseUtils.QurioPartDefinition);
 
         UpdateData();
     }
@@ -208,7 +212,6 @@ public sealed class MHRMonster : CommonMonster
             return;
 
         Variant |= VariantType.Frenzy;
-        _qurioThreshold = new MHRMonsterPart(MHRiseUtils.QurioPartDefinition);
     }
 
     [ScannableMethod]

--- a/HunterPie.Integrations/Datasources/MonsterHunterRise/Entity/Game/MHRGame.cs
+++ b/HunterPie.Integrations/Datasources/MonsterHunterRise/Entity/Game/MHRGame.cs
@@ -304,12 +304,20 @@ public sealed class MHRGame : CommonGame
 
         int monsterId = await Memory.ReadAsync<int>(monsterAddress + 0x2D4);
 
+        nint monsterTypePtr = await Memory.ReadPtrAsync(
+            address: monsterAddress,
+            offsets: AddressMap.Get<int[]>("MONSTER_TYPE_OFFSETS")
+        );
+        int monsterType = await Memory.ReadAsync<int>(monsterTypePtr + 0x5C);
+
         var monster = new MHRMonster(
             process: Process,
             scanService: ScanService,
             address: monsterAddress,
-            id: monsterId
+            id: monsterId,
+            monsterType: (MonsterType)monsterType
         );
+
         _monsters.Add(monsterAddress, monster);
         Monsters.Add(monster);
 

--- a/HunterPie.Integrations/Datasources/MonsterHunterWilds/Entity/Enemy/MHWildsMonster.cs
+++ b/HunterPie.Integrations/Datasources/MonsterHunterWilds/Entity/Enemy/MHWildsMonster.cs
@@ -18,6 +18,7 @@ using HunterPie.Integrations.Datasources.MonsterHunterWilds.Definitions.Monster;
 using HunterPie.Integrations.Datasources.MonsterHunterWilds.Entity.Crypto;
 using HunterPie.Integrations.Datasources.MonsterHunterWilds.Entity.Enemy.Data;
 using HunterPie.Integrations.Datasources.MonsterHunterWilds.Utils;
+using System.Collections.Immutable;
 using System.Text;
 
 namespace HunterPie.Integrations.Datasources.MonsterHunterWilds.Entity.Enemy;
@@ -136,9 +137,9 @@ public sealed class MHWildsMonster : CommonMonster
 
     public override VariantType Variant { get; protected set; }
 
-    public override IReadOnlyCollection<IMonsterPart> Parts => _parts;
+    public override IReadOnlyCollection<IMonsterPart> Parts => _parts.ToImmutableArray();
 
-    public override IReadOnlyCollection<IMonsterAilment> Ailments => _ailments;
+    public override IReadOnlyCollection<IMonsterAilment> Ailments => _ailments.ToImmutableArray();
 
     public override IMonsterAilment Enrage => _enrage;
 

--- a/HunterPie.Integrations/HunterPie.Integrations.csproj
+++ b/HunterPie.Integrations/HunterPie.Integrations.csproj
@@ -4,8 +4,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <AssemblyVersion>2.12.0.534</AssemblyVersion>
-    <FileVersion>2.12.0.534</FileVersion>
+    <AssemblyVersion>2.12.0.537</AssemblyVersion>
+    <FileVersion>2.12.0.537</FileVersion>
 	<Authors>Haato</Authors>
 	<Description></Description>
     <Version>2.12.0.0</Version>

--- a/HunterPie.Integrations/HunterPie.Integrations.csproj
+++ b/HunterPie.Integrations/HunterPie.Integrations.csproj
@@ -4,8 +4,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <AssemblyVersion>2.12.0.537</AssemblyVersion>
-    <FileVersion>2.12.0.537</FileVersion>
+    <AssemblyVersion>2.12.0.538</AssemblyVersion>
+    <FileVersion>2.12.0.538</FileVersion>
 	<Authors>Haato</Authors>
 	<Description></Description>
     <Version>2.12.0.0</Version>

--- a/HunterPie.Integrations/HunterPie.Integrations.csproj
+++ b/HunterPie.Integrations/HunterPie.Integrations.csproj
@@ -4,8 +4,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <AssemblyVersion>2.12.0.532</AssemblyVersion>
-    <FileVersion>2.12.0.532</FileVersion>
+    <AssemblyVersion>2.12.0.533</AssemblyVersion>
+    <FileVersion>2.12.0.533</FileVersion>
 	<Authors>Haato</Authors>
 	<Description></Description>
     <Version>2.12.0.0</Version>

--- a/HunterPie.Integrations/HunterPie.Integrations.csproj
+++ b/HunterPie.Integrations/HunterPie.Integrations.csproj
@@ -4,8 +4,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <AssemblyVersion>2.12.0.533</AssemblyVersion>
-    <FileVersion>2.12.0.533</FileVersion>
+    <AssemblyVersion>2.12.0.534</AssemblyVersion>
+    <FileVersion>2.12.0.534</FileVersion>
 	<Authors>Haato</Authors>
 	<Description></Description>
     <Version>2.12.0.0</Version>

--- a/HunterPie.Platforms/HunterPie.Platforms.csproj
+++ b/HunterPie.Platforms/HunterPie.Platforms.csproj
@@ -5,8 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<LangVersion>11.0</LangVersion>
-	<AssemblyVersion>1.0.0.303</AssemblyVersion>
-	<FileVersion>1.0.0.308</FileVersion>
+	<AssemblyVersion>1.0.0.305</AssemblyVersion>
+	<FileVersion>1.0.0.310</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/HunterPie.Platforms/HunterPie.Platforms.csproj
+++ b/HunterPie.Platforms/HunterPie.Platforms.csproj
@@ -5,8 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<LangVersion>11.0</LangVersion>
-	<AssemblyVersion>1.0.0.301</AssemblyVersion>
-	<FileVersion>1.0.0.306</FileVersion>
+	<AssemblyVersion>1.0.0.302</AssemblyVersion>
+	<FileVersion>1.0.0.307</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/HunterPie.Platforms/HunterPie.Platforms.csproj
+++ b/HunterPie.Platforms/HunterPie.Platforms.csproj
@@ -5,8 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<LangVersion>11.0</LangVersion>
-	<AssemblyVersion>1.0.0.305</AssemblyVersion>
-	<FileVersion>1.0.0.310</FileVersion>
+	<AssemblyVersion>1.0.0.306</AssemblyVersion>
+	<FileVersion>1.0.0.311</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/HunterPie.Platforms/HunterPie.Platforms.csproj
+++ b/HunterPie.Platforms/HunterPie.Platforms.csproj
@@ -5,8 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	<LangVersion>11.0</LangVersion>
-	<AssemblyVersion>1.0.0.302</AssemblyVersion>
-	<FileVersion>1.0.0.307</FileVersion>
+	<AssemblyVersion>1.0.0.303</AssemblyVersion>
+	<FileVersion>1.0.0.308</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/HunterPie.Platforms/Windows/Vault/WindowsCredentialVault.cs
+++ b/HunterPie.Platforms/Windows/Vault/WindowsCredentialVault.cs
@@ -81,13 +81,23 @@ internal class WindowsCredentialVault : ICredentialVault
         if (password is not { })
             return null;
 
-        string decryptedPassword = _cryptoService.Decrypt(password);
+        try
+        {
+            string decryptedPassword = _cryptoService.Decrypt(password);
 
-        CredFree(handle);
-
-        return new Credential(
-            Username: username,
-            Password: decryptedPassword
-        );
+            return new Credential(
+                Username: username,
+                Password: decryptedPassword
+            );
+        }
+        catch (Exception ex)
+        {
+            _logger.Error($"Failed to decrypt password: {ex}");
+            return null;
+        }
+        finally
+        {
+            CredFree(handle);
+        }
     }
 }

--- a/HunterPie.UI/Architecture/Converters/FertilizerToNameConverter.cs
+++ b/HunterPie.UI/Architecture/Converters/FertilizerToNameConverter.cs
@@ -1,4 +1,5 @@
 ﻿using HunterPie.Core.Client.Localization;
+using HunterPie.DI;
 using HunterPie.Integrations.Datasources.MonsterHunterWorld.Entity.Environment.Activities.Enums;
 using System;
 using System.Globalization;
@@ -6,14 +7,17 @@ using System.Windows.Data;
 
 namespace HunterPie.UI.Architecture.Converters;
 
+#nullable enable
 public class FertilizerToNameConverter : IValueConverter
 {
-    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    private static ILocalizationRepository LocalizationRepository => DependencyContainer.Get<ILocalizationRepository>();
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         if (value is not Fertilizer fertilizer)
             throw new ArgumentException("value must be a Fertilizer");
 
-        string localizationId = fertilizer switch
+        string? localizationId = fertilizer switch
         {
             Fertilizer.None => "FERTILIZER_NONE_STRING",
             Fertilizer.PlantS => "FERTILIZER_PLANT_S_STRING",
@@ -24,11 +28,14 @@ public class FertilizerToNameConverter : IValueConverter
             Fertilizer.HoneyL => "FERTILIZER_HONEY_L_STRING",
             Fertilizer.GrowthS => "FERTILIZER_GROWTH_S_STRING",
             Fertilizer.GrowthL => "FERTILIZER_GROWTH_L_STRING",
-            _ => throw new ArgumentOutOfRangeException(nameof(value), value, null)
+            _ => null
         };
 
-        return Localization.QueryString($"//Strings/Fertilizers/Fertilizer[@Id='{localizationId}']");
+        if (localizationId is null)
+            return null;
+
+        return LocalizationRepository.FindStringBy($"//Strings/Fertilizers/Fertilizer[@Id='{localizationId}']");
     }
 
-    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotImplementedException();
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) => throw new NotImplementedException();
 }

--- a/HunterPie.UI/HunterPie.UI.csproj
+++ b/HunterPie.UI/HunterPie.UI.csproj
@@ -5,8 +5,8 @@
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <Configurations>Debug;Release;Deploy</Configurations>
-    <AssemblyVersion>2.12.0.917</AssemblyVersion>
-    <FileVersion>2.12.0.920</FileVersion>
+    <AssemblyVersion>2.12.0.925</AssemblyVersion>
+    <FileVersion>2.12.0.928</FileVersion>
     <LangVersion>11.0</LangVersion>
     <Authors>Haato</Authors>
     <Version>2.12.0.0</Version>

--- a/HunterPie.UI/HunterPie.UI.csproj
+++ b/HunterPie.UI/HunterPie.UI.csproj
@@ -5,8 +5,8 @@
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <Configurations>Debug;Release;Deploy</Configurations>
-    <AssemblyVersion>2.12.0.928</AssemblyVersion>
-    <FileVersion>2.12.0.931</FileVersion>
+    <AssemblyVersion>2.12.0.929</AssemblyVersion>
+    <FileVersion>2.12.0.932</FileVersion>
     <LangVersion>11.0</LangVersion>
     <Authors>Haato</Authors>
     <Version>2.12.0.0</Version>

--- a/HunterPie.UI/HunterPie.UI.csproj
+++ b/HunterPie.UI/HunterPie.UI.csproj
@@ -5,8 +5,8 @@
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <Configurations>Debug;Release;Deploy</Configurations>
-    <AssemblyVersion>2.12.0.914</AssemblyVersion>
-    <FileVersion>2.12.0.917</FileVersion>
+    <AssemblyVersion>2.12.0.915</AssemblyVersion>
+    <FileVersion>2.12.0.918</FileVersion>
     <LangVersion>11.0</LangVersion>
     <Authors>Haato</Authors>
     <Version>2.12.0.0</Version>

--- a/HunterPie.UI/HunterPie.UI.csproj
+++ b/HunterPie.UI/HunterPie.UI.csproj
@@ -5,8 +5,8 @@
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <Configurations>Debug;Release;Deploy</Configurations>
-    <AssemblyVersion>2.12.0.916</AssemblyVersion>
-    <FileVersion>2.12.0.919</FileVersion>
+    <AssemblyVersion>2.12.0.917</AssemblyVersion>
+    <FileVersion>2.12.0.920</FileVersion>
     <LangVersion>11.0</LangVersion>
     <Authors>Haato</Authors>
     <Version>2.12.0.0</Version>

--- a/HunterPie.UI/HunterPie.UI.csproj
+++ b/HunterPie.UI/HunterPie.UI.csproj
@@ -5,8 +5,8 @@
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <Configurations>Debug;Release;Deploy</Configurations>
-    <AssemblyVersion>2.12.0.915</AssemblyVersion>
-    <FileVersion>2.12.0.918</FileVersion>
+    <AssemblyVersion>2.12.0.916</AssemblyVersion>
+    <FileVersion>2.12.0.919</FileVersion>
     <LangVersion>11.0</LangVersion>
     <Authors>Haato</Authors>
     <Version>2.12.0.0</Version>

--- a/HunterPie.UI/HunterPie.UI.csproj
+++ b/HunterPie.UI/HunterPie.UI.csproj
@@ -5,8 +5,8 @@
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <Configurations>Debug;Release;Deploy</Configurations>
-    <AssemblyVersion>2.12.0.925</AssemblyVersion>
-    <FileVersion>2.12.0.928</FileVersion>
+    <AssemblyVersion>2.12.0.928</AssemblyVersion>
+    <FileVersion>2.12.0.931</FileVersion>
     <LangVersion>11.0</LangVersion>
     <Authors>Haato</Authors>
     <Version>2.12.0.0</Version>

--- a/HunterPie.UI/HunterPie.UI.csproj
+++ b/HunterPie.UI/HunterPie.UI.csproj
@@ -5,8 +5,8 @@
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <Configurations>Debug;Release;Deploy</Configurations>
-    <AssemblyVersion>2.12.0.913</AssemblyVersion>
-    <FileVersion>2.12.0.916</FileVersion>
+    <AssemblyVersion>2.12.0.914</AssemblyVersion>
+    <FileVersion>2.12.0.917</FileVersion>
     <LangVersion>11.0</LangVersion>
     <Authors>Haato</Authors>
     <Version>2.12.0.0</Version>

--- a/HunterPie.UI/Overlay/Components/WidgetBase.xaml.cs
+++ b/HunterPie.UI/Overlay/Components/WidgetBase.xaml.cs
@@ -101,7 +101,7 @@ public partial class WidgetBase : Window, INotifyPropertyChanged
         if (_counter >= 30)
         {
             RenderingTime = (DateTime.UtcNow - _lastRender).TotalMilliseconds;
-            Dispatcher.Invoke(ForceAlwaysOnTop, DispatcherPriority.Render);
+            ForceAlwaysOnTop();
             _counter = 0;
         }
 

--- a/HunterPie.UI/Overlay/Widgets/Monster/MonsterContextHandler.cs
+++ b/HunterPie.UI/Overlay/Widgets/Monster/MonsterContextHandler.cs
@@ -199,6 +199,7 @@ public class MonsterContextHandler : BossMonsterViewModel, IContextHandler, IDis
 
         MaxHealth = Context.MaxHealth;
         Health = Context.Health;
+
         HandleTargetUpdate(
             lockOnTarget: Context.Target,
             manualTarget: Context.ManualTarget,
@@ -221,10 +222,8 @@ public class MonsterContextHandler : BossMonsterViewModel, IContextHandler, IDis
 
             foreach (Element weakness in Context.Weaknesses)
                 Weaknesses.Add(weakness);
-        });
 
-        if (Parts.Count != Context.Parts.Count || Ailments.Count != Context.Ailments.Count)
-            UIThread.BeginInvoke(() =>
+            if (Parts.Count != Context.Parts.Count || Ailments.Count != Context.Ailments.Count)
             {
                 foreach (IMonsterPart part in Context.Parts)
                 {
@@ -251,9 +250,8 @@ public class MonsterContextHandler : BossMonsterViewModel, IContextHandler, IDis
 
                     Ailments.Add(new MonsterAilmentContextHandler(Context, ailment, Config));
                 }
-
-
-            });
+            }
+        });
     }
 
     private void AddEnrage() => UIThread.BeginInvoke(() => Ailments.Add(new MonsterAilmentContextHandler(Context, Context.Enrage, Config)));

--- a/HunterPie.UI/Overlay/Widgets/Monster/MonsterWidgetContextHandler.cs
+++ b/HunterPie.UI/Overlay/Widgets/Monster/MonsterWidgetContextHandler.cs
@@ -123,7 +123,7 @@ public class MonsterWidgetContextHandler : IContextHandler
                     inferredTarget: _context.Game.TargetDetectionService.Infer(it.Context)
                 );
 
-                return it.IsAlive && target == Target.Self;
+                return it.Context.Health > 0 && target == Target.Self;
             }).ToArray();
 
         _viewModel.Monster = targets.SingleOrNull();

--- a/HunterPie.UI/Overlay/Widgets/Monster/MonsterWidgetContextHandler.cs
+++ b/HunterPie.UI/Overlay/Widgets/Monster/MonsterWidgetContextHandler.cs
@@ -34,16 +34,16 @@ public class MonsterWidgetContextHandler : IContextHandler
         _viewModel = _view.ViewModel;
         _context = context;
 
-        UpdateData();
         HookEvents();
+        UpdateData();
     }
 
     private void UpdateData()
     {
         foreach (IMonster monster in _context.Game.Monsters)
         {
-            _viewModel.Monsters.Add(new MonsterContextHandler(_context.Game, monster, Settings));
             monster.OnTargetChange += OnTargetChange;
+            _viewModel.Monsters.Add(new MonsterContextHandler(_context.Game, monster, Settings));
         }
 
         CalculateVisibleMonsters();

--- a/HunterPie/Internal/Logger/FileStreamLogWriter.cs
+++ b/HunterPie/Internal/Logger/FileStreamLogWriter.cs
@@ -44,7 +44,7 @@ internal class FileStreamLogWriter : ILogWriter
 
     public void Dispose()
     {
-        Stream.Dispose();
         _isClosed = true;
+        Stream.Dispose();
     }
 }

--- a/HunterPie/Internal/Tray/TrayService.cs
+++ b/HunterPie/Internal/Tray/TrayService.cs
@@ -5,9 +5,9 @@ namespace HunterPie.Internal.Tray;
 
 public class TrayService
 {
-    private readonly ContextMenuStrip contextMenuStrip = new();
-    private readonly NotifyIcon notifyIcon = new();
-    private static TrayService _instance;
+    private readonly ContextMenuStrip _contextMenuStrip = new();
+    private readonly NotifyIcon _notifyIcon = new();
+    private static TrayService? _instance;
 
     private TrayService(
         string tooltip,
@@ -15,33 +15,42 @@ public class TrayService
         Icon icon
     )
     {
-        notifyIcon.BalloonTipTitle = tooltip;
-        notifyIcon.Text = text;
-        notifyIcon.Icon = icon;
-        notifyIcon.Visible = true;
-        notifyIcon.ContextMenuStrip = contextMenuStrip;
+        _notifyIcon.BalloonTipTitle = tooltip;
+        _notifyIcon.Text = text;
+        _notifyIcon.Icon = icon;
+        _notifyIcon.Visible = true;
+        _notifyIcon.ContextMenuStrip = _contextMenuStrip;
     }
 
     internal static void Initialize(
         string tooltip,
         string text,
         Icon icon
-    ) => _instance = new(tooltip, text, icon);
+    ) => _instance = new TrayService(tooltip, text, icon);
 
     internal static void Dispose()
     {
         if (_instance is null)
             return;
 
-        _instance.contextMenuStrip.Dispose();
-        _instance.notifyIcon.Dispose();
+        _instance._contextMenuStrip.Dispose();
+        _instance._notifyIcon.Dispose();
 
         _instance = null;
     }
 
-    public static void AddDoubleClickHandler(MouseEventHandler callback) => _instance.notifyIcon.MouseDoubleClick += callback;
+    public static void AddDoubleClickHandler(MouseEventHandler callback)
+    {
+        if (_instance is null)
+            return;
 
-    public static ToolStripMenuItem AddItem(string name) => _instance.contextMenuStrip.Items.Add(name) as ToolStripMenuItem;
+        _instance._notifyIcon.MouseDoubleClick += callback;
+    }
 
-    public static ToolStripMenuItem AddMenuItem(string name, ToolStripMenuItem menu) => menu.DropDownItems.Add(name) as ToolStripMenuItem;
+    public static ToolStripMenuItem? AddItem(string name)
+    {
+        return _instance?._contextMenuStrip.Items.Add(name) as ToolStripMenuItem;
+    }
+
+    public static ToolStripMenuItem? AddMenuItem(string name, ToolStripMenuItem menu) => menu.DropDownItems.Add(name) as ToolStripMenuItem;
 }

--- a/HunterPie/Properties/AssemblyInfo.cs
+++ b/HunterPie/Properties/AssemblyInfo.cs
@@ -11,5 +11,5 @@ using System.Windows;
                                               // app, or any theme specific resource dictionaries)
 )]
 
-[assembly: AssemblyVersion("2.12.0.854")]
-[assembly: AssemblyFileVersion("2.12.0.854")]
+[assembly: AssemblyVersion("2.12.0.855")]
+[assembly: AssemblyFileVersion("2.12.0.855")]

--- a/HunterPie/Properties/AssemblyInfo.cs
+++ b/HunterPie/Properties/AssemblyInfo.cs
@@ -11,5 +11,5 @@ using System.Windows;
                                               // app, or any theme specific resource dictionaries)
 )]
 
-[assembly: AssemblyVersion("2.12.0.855")]
-[assembly: AssemblyFileVersion("2.12.0.855")]
+[assembly: AssemblyVersion("2.12.0.863")]
+[assembly: AssemblyFileVersion("2.12.0.863")]

--- a/HunterPie/Properties/AssemblyInfo.cs
+++ b/HunterPie/Properties/AssemblyInfo.cs
@@ -11,5 +11,5 @@ using System.Windows;
                                               // app, or any theme specific resource dictionaries)
 )]
 
-[assembly: AssemblyVersion("2.12.0.852")]
-[assembly: AssemblyFileVersion("2.12.0.852")]
+[assembly: AssemblyVersion("2.12.0.853")]
+[assembly: AssemblyFileVersion("2.12.0.853")]

--- a/HunterPie/Properties/AssemblyInfo.cs
+++ b/HunterPie/Properties/AssemblyInfo.cs
@@ -11,5 +11,5 @@ using System.Windows;
                                               // app, or any theme specific resource dictionaries)
 )]
 
-[assembly: AssemblyVersion("2.12.0.853")]
-[assembly: AssemblyFileVersion("2.12.0.853")]
+[assembly: AssemblyVersion("2.12.0.854")]
+[assembly: AssemblyFileVersion("2.12.0.854")]

--- a/HunterPie/Properties/AssemblyInfo.cs
+++ b/HunterPie/Properties/AssemblyInfo.cs
@@ -11,5 +11,5 @@ using System.Windows;
                                               // app, or any theme specific resource dictionaries)
 )]
 
-[assembly: AssemblyVersion("2.12.0.851")]
-[assembly: AssemblyFileVersion("2.12.0.851")]
+[assembly: AssemblyVersion("2.12.0.852")]
+[assembly: AssemblyFileVersion("2.12.0.852")]

--- a/HunterPie/Properties/AssemblyInfo.cs
+++ b/HunterPie/Properties/AssemblyInfo.cs
@@ -11,5 +11,5 @@ using System.Windows;
                                               // app, or any theme specific resource dictionaries)
 )]
 
-[assembly: AssemblyVersion("2.12.0.866")]
-[assembly: AssemblyFileVersion("2.12.0.866")]
+[assembly: AssemblyVersion("2.12.0.867")]
+[assembly: AssemblyFileVersion("2.12.0.867")]

--- a/HunterPie/Properties/AssemblyInfo.cs
+++ b/HunterPie/Properties/AssemblyInfo.cs
@@ -11,5 +11,5 @@ using System.Windows;
                                               // app, or any theme specific resource dictionaries)
 )]
 
-[assembly: AssemblyVersion("2.12.0.863")]
-[assembly: AssemblyFileVersion("2.12.0.863")]
+[assembly: AssemblyVersion("2.12.0.866")]
+[assembly: AssemblyFileVersion("2.12.0.866")]


### PR DESCRIPTION
- Fixed null exception when accessing `TrayService` during the auto-update process
- Fixed error when fertilizer name converter would receive an invalid fertilizer
- Fixed issue when iterating parts & ailments array on monster spawn
- Removed Dispatcher call from `OnRender`
- Fixed Qurio Threshold not being displayed anymore (fixes #646)
- Fixed monster not targeting when starting HunterPie mid-quest