### PR TITLE
Fix(UI): Focus buttons on click to trigger textbox binding source updates

### DIFF
--- a/HunterPie.UI/Architecture/ClickableControl.cs
+++ b/HunterPie.UI/Architecture/ClickableControl.cs
@@ -7,6 +7,11 @@ namespace HunterPie.UI.Architecture;
 
 public class ClickableControl : UserControl
 {
+    static ClickableControl()
+    {
+        FocusableProperty.OverrideMetadata(typeof(ClickableControl), new FrameworkPropertyMetadata(true));
+    }
+
     private bool _isMouseInside;
     private bool _isMouseDown;
 
@@ -26,6 +31,7 @@ public class ClickableControl : UserControl
 
         _isMouseDown = true;
         e.Handled = true;
+        Focus();
     }
 
     protected override void OnMouseLeftButtonUp(MouseButtonEventArgs e)


### PR DESCRIPTION
Sometimes changing the abnormality tray name doesn't get saved:

https://github.com/user-attachments/assets/8e01d9f1-6ede-4042-89dd-574b217d6e02

This PR makes the Back button focusable, so clicking it triggers TextBox's OnLostFocus and updates the binding source value.

See WPF's Button focuses itself after disabling default behavior in OnMouseLeftButtonDown: https://github.com/dotnet/wpf/blob/4bd646467b69e97898fd126772d9dcdb8b1ed314/src/Microsoft.DotNet.Wpf/src/PresentationFramework/System/Windows/Controls/Primitives/ButtonBase.cs#L418-L422

After:

https://github.com/user-attachments/assets/fab7eff2-98cd-4304-8507-d9d37820cf80


