### PR TITLE
Fix(UI): Set WPF language to ensure proper text rendering

### DIFF
--- a/HunterPie/App.xaml.cs
+++ b/HunterPie/App.xaml.cs
@@ -11,10 +11,12 @@ using HunterPie.UI.Main.Views;
 using HunterPie.Usecases;
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Windows;
 using System.Windows.Interop;
+using System.Windows.Markup;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Threading;
@@ -47,6 +49,7 @@ public partial class App : Application
         ShutdownMode = ShutdownMode.OnMainWindowClose;
 
         CheckIfHunterPiePathIsSafe();
+        SetupLanguage();
         SetupFrameRate();
         SetupRenderingMode();
         InitializeMainView();
@@ -77,6 +80,18 @@ public partial class App : Application
         );
 
         Shutdown();
+    }
+
+    private void SetupLanguage()
+    {
+        string fileName = ClientConfig.Config.Client.Language.Current;
+        string language = fileName[..^".xml".Length];
+        Thread.CurrentThread.CurrentCulture = new CultureInfo(language);
+        Thread.CurrentThread.CurrentUICulture = new CultureInfo(language);
+        FrameworkElement.LanguageProperty.OverrideMetadata(
+            forType: typeof(FrameworkElement),
+            typeMetadata: new FrameworkPropertyMetadata(XmlLanguage.GetLanguage(language))
+        );
     }
 
     private void SetupFrameRate()


### PR DESCRIPTION
Mainly for CJK languages and when app language is set to a different one from OS.

Before:

<img width="1750" height="1048" alt="Screenshot 2025-08-09 221800" src="https://github.com/user-attachments/assets/d318e573-0680-438b-8292-7534a05d7534" />

(Maybe you can't read the language, but it should be pretty obvious that some characters have different thickness from others, and that's not normal.)

After:

<img width="1750" height="1048" alt="Screenshot 2025-08-09 221653" src="https://github.com/user-attachments/assets/66eaef85-6a8a-4681-a160-31fd1c29931f" />